### PR TITLE
Implement manually handling ICMP packets

### DIFF
--- a/ethernet/physical_unigornel.go
+++ b/ethernet/physical_unigornel.go
@@ -8,10 +8,7 @@ package ethernet
 // extern void *malloc(size_t);
 // extern void free(void *);
 import "C"
-import (
-	"fmt"
-	"unsafe"
-)
+import "unsafe"
 
 type miniosNIC struct {
 	tx   chan Packet
@@ -81,8 +78,6 @@ func (nic *miniosNIC) receiveAll() {
 		if err != nil {
 			panic(err)
 		}
-
-		fmt.Println("Got packet:", packet)
 
 		select {
 		case nic.rx <- packet:

--- a/icmp/layer.go
+++ b/icmp/layer.go
@@ -9,10 +9,12 @@ import (
 
 // Layer is the ICMP layer.
 type Layer interface {
+	Packets(p Type) <-chan Packet
 }
 
 type layer struct {
-	ip ipv4.Layer
+	ip       ipv4.Layer
+	channels map[Type]chan Packet
 }
 
 // NewLayer creates a new instance of the default ICMP layer.
@@ -24,6 +26,15 @@ func NewLayer(ip ipv4.Layer) Layer {
 	return l
 }
 
+func (layer *layer) Packets(t Type) <-chan Packet {
+	c, ok := layer.channels[t]
+	if !ok {
+		c = make(chan Packet)
+		layer.channels[t] = c
+	}
+	return c
+}
+
 func (layer *layer) run() {
 	for packet := range layer.ip.Packets(ipv4.ProtocolICMP) {
 		p, err := NewPacket(bytes.NewReader(packet.Payload))
@@ -31,17 +42,27 @@ func (layer *layer) run() {
 			continue
 		}
 
+		p.Source = packet.Source
+
 		switch p.Header.Type {
 		case EchoRequestType:
-			go layer.handleEchoRequest(packet.Source, p)
+			go layer.handleEchoRequest(p)
 		default:
+			c := layer.channels[p.Header.Type]
+			if c != nil {
+				c <- p
+			}
 		}
+	}
+
+	for _, c := range layer.channels {
+		close(c)
 	}
 }
 
-func (layer *layer) handleEchoRequest(source ipv4.Address, packet Packet) {
+func (layer *layer) handleEchoRequest(packet Packet) {
 	data := packet.Data.(Echo)
 	reply := NewEchoReply(data.Header.Identifier, data.Header.SequenceNumber, data.Payload)
-	p := ipv4.NewPacketTo(source, ipv4.ProtocolICMP, common.PacketToBytes(reply))
+	p := ipv4.NewPacketTo(packet.Source, ipv4.ProtocolICMP, common.PacketToBytes(reply))
 	layer.ip.Send(p)
 }

--- a/icmp/layer.go
+++ b/icmp/layer.go
@@ -21,7 +21,8 @@ type layer struct {
 // NewLayer creates a new instance of the default ICMP layer.
 func NewLayer(ip ipv4.Layer) Layer {
 	l := &layer{
-		ip: ip,
+		ip:       ip,
+		channels: make(map[Type]chan Packet),
 	}
 	go l.run()
 	return l

--- a/icmp/packet.go
+++ b/icmp/packet.go
@@ -51,7 +51,9 @@ type Data interface {
 type Packet struct {
 	Header Header
 	Data   Data
-	Source ipv4.Address
+
+	// Address is either the destination or source address.
+	Address ipv4.Address
 }
 
 // NewPacket will read a packet from a reader.

--- a/icmp/packet.go
+++ b/icmp/packet.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 
 	"github.com/unigornel/go-tcpip/common"
+	"github.com/unigornel/go-tcpip/ipv4"
 )
 
 // Type is the type of the ICMP packet.
@@ -50,6 +51,7 @@ type Data interface {
 type Packet struct {
 	Header Header
 	Data   Data
+	Source ipv4.Address
 }
 
 // NewPacket will read a packet from a reader.


### PR DESCRIPTION
Add a `Packets` function to `icmp.Layer` to manually receive some ICMP packets. This is necessary to build an application that can ping a remote host.
